### PR TITLE
GHC 7.10 cleanup, Travis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.virtualenv
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+*.prof
+*.aux
+*.hp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: haskell
+
+ghc:
+  - 7.0.4
+  - 7.4.2
+  - 7.6.3
+  - 7.8.4
+
+install:
+  - cabal update
+  - cabal install -j --only-dependencies
+
+script:
+  - cabal configure -ftests
+  - cabal build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 ## 0.6.1
-* Fixed tab-related warnings in GHC 7.10
+* Fixed warnings in GHC 7.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.6.1
+* Fixed tab-related warnings in GHC 7.10

--- a/Data/Reify.hs
+++ b/Data/Reify.hs
@@ -5,13 +5,15 @@ module Data.Reify (
         reifyGraph
         ) where
 
-import Control.Concurrent.MVar
-import System.Mem.StableName
-import Data.IntMap as M
-import Unsafe.Coerce
-
 import Control.Applicative
+import Control.Concurrent.MVar
+
+import Data.IntMap as M
 import Data.Reify.Graph
+
+import System.Mem.StableName
+
+import Unsafe.Coerce
 
 
 -- | 'MuRef' is a class that provided a way to reference into a specific type,
@@ -78,10 +80,9 @@ hashDynStableName :: DynStableName -> Int
 hashDynStableName (DynStableName sn) = hashStableName sn
 
 instance Eq DynStableName where
-	(DynStableName sn1) == (DynStableName sn2) = sn1 == sn2
+    (DynStableName sn1) == (DynStableName sn2) = sn1 == sn2
 
 makeDynStableName :: a -> IO DynStableName
 makeDynStableName a = do
-	st <- makeStableName a
-	return $ DynStableName (unsafeCoerce st)
-	
+    st <- makeStableName a
+    return $ DynStableName (unsafeCoerce st)

--- a/Data/Reify.hs
+++ b/Data/Reify.hs
@@ -1,11 +1,13 @@
-{-# LANGUAGE  TypeFamilies, RankNTypes #-}
+{-# LANGUAGE CPP, TypeFamilies, RankNTypes #-}
 module Data.Reify (
         MuRef(..),
         module Data.Reify.Graph,
         reifyGraph
         ) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Concurrent.MVar
 
 import Data.IntMap as M

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# data-reify [![Hackage version](https://img.shields.io/hackage/v/data-reify.svg?style=flat)](http://hackage.haskell.org/package/data-reify) [![Build Status](https://img.shields.io/travis/ku-fpg/data-reify.svg?style=flat)](https://travis-ci.org/ku-fpg/data-reify)
+
+`data-reify` provided the ability to turn recursive structures into explicit graphs. Many (implicitly or explicitly) recursive data structure can be given this ability, via a type class instance. This gives an alternative to using `Ref` for observable sharing.
+
+Observable sharing in general is unsafe, so we use the IO monad to bound this effect, but can be used safely even with `unsafePerformIO` if some simple conditions are met. Typically this package will be used to tie the knot with DSLs that depend of observable sharing, like Lava.
+
+Providing an instance for `MuRef` is the mechanism for allowing a structure to be reified into a graph, and several examples of this are provided.
+
+History: Version 0.1 used unsafe pointer compares. Version 0.2 of `data-reify` used StableNames, and was much faster. Version 0.3 provided two versions of `MuRef`, the mono-typed version, for trees of a single type, and the dynamic-typed version, for trees of different types. Version 0.4 used `Int` as a synonym for `Unique` rather than `Data.Unique` for node ids, by popular demand. Version 0.5 merged the mono-typed and dynamic version again, by using `DynStableName`, an unphantomized version of `StableName`.

--- a/data-reify.cabal
+++ b/data-reify.cabal
@@ -35,7 +35,8 @@ Copyright:           (c) 2009 Andy Gill
 Homepage:            http://www.ittc.ku.edu/csdl/fpg/Tools/IOReification
 Stability:	     alpha
 build-type: 	     Simple
-Cabal-Version:       >= 1.6
+Cabal-Version:       >= 1.8
+extra-source-files:  CHANGELOG.md, README.md
 
 Flag tests
   Description: Enable full development tree
@@ -50,51 +51,58 @@ Library
   Ghc-Options:  -Wall
 
 Executable data-reify-test1
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test1.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 
 Executable data-reify-test2
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test2.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 Executable data-reify-test3
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test3.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 Executable data-reify-test4
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test4.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 Executable data-reify-test5
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test5.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 Executable data-reify-test6
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test6.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False
 
 Executable data-reify-test7
-  Build-Depends:  base
+  Build-Depends:  base, data-reify
   Main-Is:        Test7.hs
-  Hs-Source-Dirs: ., test
+  Hs-Source-Dirs: test
+  ghc-options:    -Wall
   if !flag(tests)
     buildable: False

--- a/data-reify.cabal
+++ b/data-reify.cabal
@@ -1,5 +1,5 @@
 Name:               data-reify
-Version:            0.6
+Version:            0.6.1
 Synopsis:           Reify a recursive data structure into an explicit graph.
 Description:	    'data-reify' provided the ability to turn recursive structures into explicit graphs. 
 		    Many (implicitly or explicitly) recursive data structure can be given this ability, via

--- a/test/Test1.hs
+++ b/test/Test1.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP, TypeFamilies #-}
 module Main (main) where
 
 import           Control.Applicative hiding (Const)
 
 import qualified Data.Foldable as F
-import qualified Data.Traversable as T
+#if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid
+#endif
 import           Data.Reify
+import qualified Data.Traversable as T
 
 newtype Mu a = In (a (Mu a))
 

--- a/test/Test1.hs
+++ b/test/Test1.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE TypeFamilies #-}
-module Main where
+module Main (main) where
 
-import qualified Data.Traversable as T
+import           Control.Applicative hiding (Const)
+
 import qualified Data.Foldable as F
-import Data.Monoid
-import Control.Applicative hiding (Const)
-import Data.Unique
-import Data.Reify
+import qualified Data.Traversable as T
+import           Data.Monoid
+import           Data.Reify
 
 newtype Mu a = In (a (Mu a))
 
@@ -22,27 +22,29 @@ data List a b = Cons a b | Nil
 type MyList a = Mu (List a)
 
 instance Functor (List a) where
-   fmap f Nil = Nil
+   fmap _ Nil = Nil
    fmap f (Cons a b) = Cons a (f b)
 
 instance F.Foldable (List a) where
-   foldMap f Nil        = mempty
-   foldMap f (Cons a b) = f b
+   foldMap _ Nil        = mempty
+   foldMap f (Cons _ b) = f b
 
 instance T.Traversable (List a) where
   traverse f (Cons a b) = Cons <$> pure a <*> f b
-  traverse f Nil        = pure Nil
+  traverse _ Nil        = pure Nil
 
-
+main :: IO ()
 main = do
         let g1 :: MyList Int
             g1 = In (Cons 1 (In (Cons 2 (In Nil))))
         reifyGraph g1 >>= print
-        let g2 =  In (Cons 1 (In (Cons 2 g2)))
+        let g2 :: MyList Int
+            g2 =  In (Cons 1 (In (Cons 2 g2)))
         reifyGraph g2  >>= print
         let count n m | n == m    = In Nil
                       | otherwise = In (Cons n (count (succ n) m)) 
-        let g3 = count 1 1000 
+        let g3 :: MyList Int
+            g3 = count 1 1000 
         reifyGraph g3  >>= print
         
         

--- a/test/Test2.hs
+++ b/test/Test2.hs
@@ -1,18 +1,16 @@
 {-# LANGUAGE TypeFamilies #-}
-module Main where
+module Main (main) where
 
+import           Control.Applicative hiding (Const)
+
+import           Data.Reify
 import qualified Data.Traversable as T
-import qualified Data.Foldable as F
-import Data.Monoid
-import Control.Applicative hiding (Const)
-import Data.Unique
-import Data.Reify
-import Control.Monad
 
 -- Notice how there is nothing Mu-ish about this datatype.
 data State a b = State a [(b,State a b)]
         deriving Show
 
+s0, s1, s2 :: State Int Bool
 s0 = State 0 [(True,s1),(False,s2)]
 s1 = State 1 [(True,s0),(False,s1)]
 s2 = State 2 [(True,s1),(False,s0)]
@@ -28,10 +26,8 @@ instance MuRef (State a b) where
 instance Functor (StateDeRef a b) where
    fmap f (StateDeRef a tr) = StateDeRef a [ (b,f s) | (b,s) <- tr ]
 
-
-main = do
-        reifyGraph s0 >>= print
-
+main :: IO ()
+main = reifyGraph s0 >>= print
         
 {- Alt:
 

--- a/test/Test3.hs
+++ b/test/Test3.hs
@@ -1,15 +1,12 @@
 {-# LANGUAGE TypeFamilies #-}
-module Main where
+module Main (main) where
 
-import qualified Data.Traversable as T
+import           Control.Applicative hiding (Const)
+
+import           Data.Monoid
 import qualified Data.Foldable as F
-import Data.Monoid
-import Control.Applicative hiding (Const)
-import Data.Unique
-import Control.Monad
-
-import Data.Reify
-        
+import           Data.Reify
+import qualified Data.Traversable as T
 
 data Signal = Signal (Circuit Signal)
 
@@ -23,7 +20,7 @@ data Circuit c
  | Var String
         deriving (Eq,Ord)
 
-newtype Mu a = In (a (Mu a))
+-- newtype Mu a = In (a (Mu a))
 
 instance MuRef Signal where
   type DeRef Signal = Circuit
@@ -41,10 +38,17 @@ instance Show c => Show (Circuit c) where
   show (Delay b)        = "delay(" ++ show b ++ ")"
   show (Var str)        = show str
   
+and2 :: (Signal, Signal) -> Signal
 and2 (s1,s2) = Signal (And2 (s1,s2))
+
+xor2 :: (Signal, Signal) -> Signal
 xor2 (s1,s2) = Signal (Xor2 (s1,s2))
+
+mux2 :: Signal -> (Signal, Signal) -> Signal
 mux2 s (s1,s2) = Signal (Mux2 s (s1,s2))
-delay s        = Signal (Delay s)
+
+-- delay :: Signal -> Signal
+-- delay s = Signal (Delay s)
 
 pad :: String -> Signal
 pad nm = Signal (Var nm)
@@ -52,6 +56,7 @@ pad nm = Signal (Var nm)
 data BitValue = High | Low
         deriving (Eq,Ord)
 
+high, low :: Signal
 high = Signal $ Const High
 low  = Signal $ Const Low
 
@@ -60,65 +65,64 @@ instance Show BitValue where
    show Low  = "low"
 
 halfAdder :: (Signal,Signal) -> (Signal,Signal)
-halfAdder (a,b) = (carry,sum)
+halfAdder (a,b) = (carry,sum')
   where carry = and2 (a,b)
-        sum   = xor2 (a,b)
+        sum'  = xor2 (a,b)
 
 fullAdder :: (Signal,(Signal,Signal)) -> (Signal,Signal)
-fullAdder (cin,(a,b)) = (cout,sum)
+fullAdder (cin,(a,b)) = (cout,sum')
   where (car1,sum1) = halfAdder (a,b)
-	(car2,sum)  = halfAdder (cin,sum1)
-	cout        = xor2 (car1,car2)
+        (car2,sum') = halfAdder (cin,sum1)
+        cout        = xor2 (car1,car2)
            
 instance F.Foldable Circuit where
-   foldMap f (And2 (e1,e2)) = f e1 `mappend`  f e2
-   foldMap f (Xor2 (e1,e2)) = f e1 `mappend`  f e2
+   foldMap f (And2 (e1,e2))   = f e1 `mappend`  f e2
+   foldMap f (Xor2 (e1,e2))   = f e1 `mappend`  f e2
    foldMap f (Mux2 s (e1,e2)) = f s `mappend` f e1 `mappend`  f e2
-   foldMap f (Delay s) = f s
-   foldMap f (Const _) = mempty
-   foldMap f (Var _)  = mempty
+   foldMap f (Delay s)        = f s
+   foldMap _ (Const _)        = mempty
+   foldMap _ (Var _)          = mempty
 
 
 instance Functor Circuit where
-   fmap f (And2 (e1,e2)) = And2 (f e1,f e2)
-   fmap f (Xor2 (e1,e2)) = Xor2 (f e1,f e2)
+   fmap f (And2 (e1,e2))   = And2 (f e1,f e2)
+   fmap f (Xor2 (e1,e2))   = Xor2 (f e1,f e2)
    fmap f (Mux2 s (e1,e2)) = Mux2 (f s) (f e1,f e2)
-   fmap f (Delay s)       = Delay (f s)
-   fmap f (Const a) = Const a
-   fmap f (Var a) = Var a
+   fmap f (Delay s)        = Delay (f s)
+   fmap _ (Const a)        = Const a
+   fmap _ (Var a)          = Var a
 
 instance T.Traversable Circuit where
-  traverse f (And2 (e1,e2)) = (\ x y -> And2 (x,y)) <$> f e1 <*> f e2
-  traverse f (Xor2 (e1,e2)) = (\ x y -> Xor2 (x,y))  <$> f e1 <*> f e2
-  traverse f (Mux2 c (e1,e2)) = (\ c x y -> Mux2 c (x,y)) <$> f c <*> f e1 <*> f e2
-  traverse f (Delay s)      = Delay <$> f s
-  traverse f (Const a) = pure (Const a)
-  traverse f (Var a) = pure (Var a)
+  traverse f (And2 (e1,e2))   = (\ x y -> And2 (x,y)) <$> f e1 <*> f e2
+  traverse f (Xor2 (e1,e2))   = (\ x y -> Xor2 (x,y))  <$> f e1 <*> f e2
+  traverse f (Mux2 c (e1,e2)) = (\ c' x y -> Mux2 c' (x,y)) <$> f c <*> f e1 <*> f e2
+  traverse f (Delay s)        = Delay <$> f s
+  traverse _ (Const a)        = pure (Const a)
+  traverse _ (Var a)          = pure (Var a)
 
 rowLA :: (Signal -> (b,b) -> b) -> ((Signal,a) -> (Signal,b)) -> (Signal,[a]) ->
  (Signal,[b])
-rowLA mymux f (cin,[])   = (cin,[])
-rowLA mymux f (cin,[a]) = (car,[sum])
-   where
-           (car,sum)   = f (cin,a)
-rowLA mymux f (cin,cs) = (mux2 cout1 (cout2_lo,cout2_hi),
+rowLA _     _ (cin,[])   = (cin,[])
+rowLA _     f (cin,[a])  = (car,[sum'])
+  where (car,sum')  = f (cin,a)
+rowLA mymux f (cin,cs)   = (mux2 cout1 (cout2_lo,cout2_hi),
                     sums1 ++ 
                         [ mymux cout1 (s_lo,s_hi)
                         | (s_lo,s_hi) <- zip sums2_lo sums2_hi
                         ])
-   where
-           len = length cs `div` 2
-           (cout1,sums1) = rowLA mymux f (cin,take len cs)
-           (cout2_hi,sums2_hi) = rowLA mymux f (high,drop len cs)
-           (cout2_lo,sums2_lo) = rowLA mymux f (low,drop len cs)
+  where
+    len = length cs `div` 2
+    (cout1,sums1) = rowLA mymux f (cin,take len cs)
+    (cout2_hi,sums2_hi) = rowLA mymux f (high,drop len cs)
+    (cout2_lo,sums2_lo) = rowLA mymux f (low,drop len cs)
 
-
+main :: IO ()
 main = do
         let g1 = xor2 (xor2 (pad "a",pad "b"),g1)
         reifyGraph g1 >>= print
         let (g2,_) = rowLA mux2 fullAdder
                                 (pad "c",[ (pad $ "a" ++ show x,pad $ "b" ++ show x)
-                                     | x <- [1..20]
+                                     | x <- [1..20] :: [Int]
                                      ])
         reifyGraph g2  >>= print
 

--- a/test/Test3.hs
+++ b/test/Test3.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP, TypeFamilies #-}
 module Main (main) where
 
 import           Control.Applicative hiding (Const)
 
-import           Data.Monoid
 import qualified Data.Foldable as F
+#if !(MIN_VERSION_base(4,8,0))
+import           Data.Monoid
+#endif
 import           Data.Reify
 import qualified Data.Traversable as T
 

--- a/test/Test4.hs
+++ b/test/Test4.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE TypeFamilies #-}
-module Main where
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Main (main) where
 
-import qualified Data.Traversable as T
-import qualified Data.Foldable as F
-import Data.Monoid
---import Control.Monad
 import Control.Applicative hiding (Const)
-
 import Data.Reify
-import Control.Monad
 import System.CPUTime
 
 data List a b = Nil | Cons a b
@@ -19,28 +14,32 @@ instance MuRef [a] where
   type DeRef [a] = List a 
 
   mapDeRef f (x:xs) = Cons x <$> f xs
-  mapDeRef f []     = pure Nil
+  mapDeRef _ []     = pure Nil
   
 instance Functor (List a) where
-   fmap f Nil = Nil
+   fmap _ Nil = Nil
    fmap f (Cons a b) = Cons a (f b)
 
+main :: IO ()
 main = do
-        let g1 = [1..10]
+        let g1 :: [Int]
+            g1 = [1..10]
         reifyGraph g1 >>= print
-        let g2 = [1..10] ++ g2
+        let g2 :: [Int]
+            g2 = [1..10] ++ g2
         reifyGraph g2 >>= print
 
         -- now, some timings.
         ns <- sequence [ timeme n | n <- take 8 (iterate (*2) 1024) ]
         print $ reverse $ take 4 $ reverse [ n2 / n1 | (n1,n2) <- zip ns (tail ns) ]
 
+timeme :: Int -> IO Float
 timeme n = do
         i <- getCPUTime
         let g3 = [1..n] ++ g3
         reifyGraph g3 >>= \ (Graph xs _) -> putStr $ show (length xs)
         j <- getCPUTime
-        let n :: Float
-            n = fromIntegral ((j - i) `div` 1000000000)
-        putStrLn $ " ==> " ++ show (n / 1000)   
-        return n    
+        let n' :: Float
+            n' = fromIntegral ((j - i) `div` 1000000000)
+        putStrLn $ " ==> " ++ show (n' / 1000)   
+        return n'

--- a/test/Test5.hs
+++ b/test/Test5.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE TypeFamilies, DeriveDataTypeable #-}
-module Main where
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Main (main) where
 
-import qualified Data.Traversable as T
-import qualified Data.Foldable as F
-import Data.Monoid
 import Control.Applicative hiding (Const)
-import Data.Reify
-import Data.Dynamic
 
-import Control.Monad
+import Data.Dynamic
+import Data.Reify
+
 import System.CPUTime
 
 data List a b = Nil | Cons a b
@@ -18,13 +16,14 @@ instance Typeable a => MuRef [a] where
   type DeRef [a] = List a 
 
   mapDeRef f (x:xs) = Cons x <$> f xs
-  mapDeRef f []     = pure Nil
+  mapDeRef _ []     = pure Nil
 
 
 instance Functor (List a) where
-   fmap f Nil = Nil
+   fmap _ Nil = Nil
    fmap f (Cons a b) = Cons a (f b)
 
+main :: IO ()
 main = do
         let g1 = [1..(10::Int)]
         reifyGraph g1 >>= print
@@ -41,7 +40,7 @@ timeme n = do
         let g3 = [1..n] ++ g3
         reifyGraph g3 >>= \ (Graph xs _) -> putStr $ show (length xs)
         j <- getCPUTime
-        let n :: Float
-            n = fromIntegral ((j - i) `div` 1000000000)
-        putStrLn $ " ==> " ++ show (n / 1000)   
-        return n    
+        let n' :: Float
+            n' = fromIntegral ((j - i) `div` 1000000000)
+        putStrLn $ " ==> " ++ show (n' / 1000)   
+        return n'

--- a/test/Test7.hs
+++ b/test/Test7.hs
@@ -1,23 +1,14 @@
-{-# LANGUAGE TypeFamilies, UndecidableInstances, DeriveDataTypeable, RankNTypes, ExistentialQuantification      #-}
+{-# LANGUAGE TypeFamilies, UndecidableInstances, DeriveDataTypeable,
+             RankNTypes, ExistentialQuantification #-}
+module Main (main) where
 
-
-import qualified Data.Traversable as T
-import qualified Data.Foldable as F
-import Data.Monoid
---import Control.Monad
 import Control.Applicative hiding (Const)
-import Data.Unique
-
-import System.Environment
 
 import Data.Reify
---import Data.Reify
-import Control.Monad
-import System.CPUTime
 import Data.Typeable
-import Control.Exception as E
 
-import Data.Dynamic
+import System.CPUTime
+import System.Environment
 
 data Tree = Node Tree Tree | Leaf Int
          deriving (Show,Eq,Typeable)
@@ -27,13 +18,14 @@ data T s = N s s | L Int
 instance MuRef Tree where
   type DeRef Tree = T
   mapDeRef f (Node t1 t2) = N <$> f t1 <*> f t2
-  mapDeRef f (Leaf i)     = pure $ L i
+  mapDeRef _ (Leaf i)     = pure $ L i
 
 deepTree :: Int -> Int -> Tree
 deepTree 1 x = Leaf x
 deepTree n x = Node (deepTree (pred n) (x * 37)) (deepTree (pred n) (x * 17))
 
 -- no sharing
+deepTree' :: Int -> Tree
 deepTree' n = deepTree n 1
 
 deepTree2 :: Int -> Integer -> Tree -> Tree
@@ -41,6 +33,7 @@ deepTree2 1 v x = if v == 89235872347 then Leaf 1 else x
 deepTree2 n v x = Node (deepTree2 (pred n) (v * 37) x) (deepTree2 (pred n) (v * 17) x)
 
 -- sharing
+deepTree2' :: Int -> Tree
 deepTree2' n = let v = deepTree2 n 1 v in v
 
 timeme :: Int -> (Int -> Tree) -> IO Float
@@ -53,13 +46,13 @@ timeme n f = do
         let t :: Float
             t = fromIntegral ((j - i) `div` 1000000000)
         putStrLn $ " " ++ show n ++ " ==> " ++ show (t / 1000)   
-        return t    
+        return t
         
-
+main :: IO ()
 main = do
   (x:args) <- getArgs
-  sequence [ timeme n (case x of
+  sequence_ [ timeme n (case x of
                          "sharing"    -> deepTree2'
                          "no-sharing" -> deepTree')
-           | n <- map read args
-           ]
+            | n <- map read args
+            ]


### PR DESCRIPTION
This repo isn't a part of the ku-fpg category, so I don't have push permissions. This goes through and removes some GHC 7.10-specific errors (i.e., replaces tabs with spaces and conditionally imports new `Prelude`-subsumed modules like `Control.Applicative` and `Data.Monoid`). It also sets up integration with Travis-CI.