### PR TITLE
General cleanup and simplification

### DIFF
--- a/data-reify.cabal
+++ b/data-reify.cabal
@@ -47,7 +47,7 @@ Flag tests
 
 
 Library
-  Build-Depends: base >= 4 && < 5, containers
+  Build-Depends: base >= 4 && < 5, hashable, containers, unordered-containers
   Exposed-modules:
        Data.Reify,
        Data.Reify.Graph


### PR DESCRIPTION
* Use `HashMap` instead of `IntMap`: it's the right abstraction,
  it's much simpler to use, and it's likely a bit faster.

* Use an existentially quantified type instead of `unsafeCoerce`.
  It just seems a bit cleaner.

* Use `IntSet` instead of `Set` for performance.

* Use `BangPatterns` instead of an awkward old-school simulation
  thereof.