### PR TITLE
Fix #11 with another MVar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -152,10 +152,12 @@ script:
   # Building with tests and benchmarks...
   # build & run tests, build benchmarks
   - ${CABAL} v2-build $WITHCOMPILER ${TEST} ${BENCH} all
+  # Testing...
+  - ${CABAL} v2-test $WITHCOMPILER ${TEST} ${BENCH} all
   # cabal check...
   - (cd ${PKGDIR_data_reify} && ${CABAL} -vnormal check)
   # haddock...
   - ${CABAL} v2-haddock $WITHCOMPILER --with-haddock $HADDOCK ${TEST} ${BENCH} all
 
-# REGENDATA ("0.10",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.3",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next [????.??.??]
+* Fix a bug introduced in `data-reify-0.6.2` where `reifyGraph` could return
+  `Graph`s with duplicate key-value pairs.
+
 ## 0.6.2 [2020.09.30]
 * Use `HashMap`s and `IntSet`s internally for slightly better performance.
 

--- a/data-reify.cabal
+++ b/data-reify.cabal
@@ -58,6 +58,19 @@ Library
     ghc-options: -Wno-star-is-type
   default-language: Haskell2010
 
+test-suite spec
+  type:                exitcode-stdio-1.0
+  main-is:             Spec.hs
+  other-modules:       Data.ReifySpec
+  build-depends:       base        >= 4    && < 5
+                     , base-compat >= 0.11 && < 0.12
+                     , data-reify
+                     , hspec       == 2.*
+  build-tool-depends:  hspec-discover:hspec-discover == 2.*
+  hs-source-dirs:      spec
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts
+
 Executable data-reify-test1
   Build-Depends:  base, data-reify
   Main-Is:        Test1.hs

--- a/spec/Data/ReifySpec.hs
+++ b/spec/Data/ReifySpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Data.ReifySpec where
+
+import qualified Data.List as L
+import Data.Reify
+import Prelude ()
+import Prelude.Compat
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = parallel $
+  describe "reifyGraph" $
+    it "should produce a Graph with unique key-value pairs" $ do -- #11
+      g <- reifyGraph s1
+      nubGraph g `shouldBe` g
+
+data State = State Char [State]
+  deriving (Eq, Show)
+
+data StateDeRef r = StateDeRef Char [r]
+  deriving (Eq, Show)
+
+s1, s2, s3 :: State
+s1 = State 'a' [s2,s3]
+s2 = State 'b' [s1,s2]
+s3 = State 'c' [s2,s1]
+
+instance MuRef State where
+  type DeRef State = StateDeRef
+  mapDeRef f (State a tr) = StateDeRef a <$> traverse f tr
+
+nubGraph :: Eq (e Unique) => Graph e -> Graph e
+nubGraph (Graph netlist start) = Graph (L.nub netlist) start
+
+deriving instance Eq (e Unique) => Eq (Graph e)

--- a/spec/Spec.hs
+++ b/spec/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
This implements the fix for #11 described in https://github.com/ku-fpg/data-reify/issues/11#issuecomment-705888206. That is, it turns the `IntSet` argument to `findNodes` into an `MVar IntSet`.

Besides the bugfix itself, this commit refactors the internals of `Data.Reify` slightly to make it slightly more comprehensible at a glance.